### PR TITLE
Enhancing docs about PRNG seeding

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -582,6 +582,42 @@ Initialization
 
 * :func:`numpy.random.seed`: with an integer argument only
 
+.. warning::
+   Calling :func:`numpy.random.seed` from non-Numba code (or from :term:`object mode`
+   code) will seed the NumPy random generator, not the Numba random generator.
+   To poperly seed the Numba random generator, see example below.
+
+.. code-block:: python
+
+  from numba import njit
+  import numpy as np
+
+  @njit
+  def seed(a):
+      np.random.seed(a)
+
+  @njit
+  def rand():
+      return np.random.rand()
+
+
+  # Uncorrect seeding
+  np.random.seed(1234)
+  print(rand())
+
+  np.random.seed(1234)
+  print(rand())
+
+  # Correct seeding
+  seed(1234)
+  print(rand())
+
+  seed(1234)
+  print(rand())
+
+
+
+
 Simple random data
 ''''''''''''''''''
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1156,9 +1156,39 @@ startup with entropy drawn from the operating system.
 * :func:`random.vonmisesvariate`
 * :func:`random.weibullvariate`
 
-.. note::
+.. warning::
    Calling :func:`random.seed` from non-Numba code (or from :term:`object mode`
    code) will seed the Python random generator, not the Numba random generator.
+   To poperly seed the Numba random generator, see example below.
+
+.. code-block:: python
+
+  from numba import njit
+  import random
+
+  @njit
+  def seed(a):
+      random.seed(a)
+
+  @njit
+  def rand():
+      return random.random()
+
+
+  # Uncorrect seeding
+  random.seed(1234)
+  print(rand())
+
+  random.seed(1234)
+  print(rand())
+
+  # Correct seeding
+  seed(1234)
+  print(rand())
+
+  seed(1234)
+  print(rand())
+
 
 .. note::
    Since version 0.28.0, the generator is thread-safe and fork-safe.  Each


### PR DESCRIPTION
Hello,

This PR directly follows my [proposition](https://github.com/numba/numba/issues/6002#issuecomment-850429729) in #6002.

The goal was to enhance the current documentation to be more clear about PRNG seeding. A note was already present for the Python `random` module but not the the NumPy one.

It took the liberty to add a minimal working example in both cases, as well as labelling it as a *warning* to have more impact.

I will gladly accept any comment or suggestion from your side.

Thanks :-)

# Updated doc.

![python_seed](https://user-images.githubusercontent.com/27275099/120036606-ae325800-c000-11eb-9e56-f1d90544265f.png)
![numpy_seed](https://user-images.githubusercontent.com/27275099/120036614-b2f70c00-c000-11eb-82b0-a71bc2c5b7b6.png)
